### PR TITLE
Hotfix/update browser distribuition

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,3 @@
-dist/aws-edge-locations.csv
-dist/aws-edge-locations.js
 data/
 .github/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ If you copy it in your web project (assuming the file resides in `lib`), you can
 <html>
     <head>
         <script src="lib/aws-edge-locations.js"></script>
+        <!-- 
+          Note: you can also drop it straight from unpkg CDN
+
+          <script src="https://unpkg.com/aws-edge-locations@x.x.x/dist/aws-edge-locations.js"></script> 
+        -->
     </head>
     <body>
         <script>

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.0",
   "description": "List of AWS edge location code prefixes",
   "main": "index.js",
+  "browser": "dist/aws-edge-locations.js",
   "scripts": {
     "test": "mocha",
     "download-airports": "mkdir -p data && curl -L --silent https://datahub.io/core/airport-codes/r/airport-codes.json --output data/airport-codes.json",


### PR DESCRIPTION
Based on this issue feedback https://github.com/tobilg/aws-edge-locations/issues/3#issuecomment-539924596

- Distribute `.csv` dataset, for those like me which have backend csv parsers already in place
- Distribute `aws-edge-locations.js` (browser version) which can be now either imported or dropped straight at html via file reference or unpkg CDN link https://unpkg.com/aws-edge-locations@x.x.x/dist/aws-edge-locations.js